### PR TITLE
Add OPENAI_BASE_URL support for OpenAI-compatible servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@
 # Option 3: OpenAI
 # OPENAI_API_KEY=your_openai_api_key
 
+# Option 4: OpenAI-compatible server (Llama.cpp, VLLM, LM Studio, OpenRouter, etc.)
+# Set OPENAI_BASE_URL to your endpoint and list the model names you want exposed in the UI.
+# OPENAI_API_KEY is optional for local servers; required for hosted ones like OpenRouter.
+# OPENAI_BASE_URL=http://localhost:8080/v1
+# OPENAI_MODELS=llama-3.1-8b-instruct,qwen2.5-coder-7b
+
 # ── Optional: Tracing (choose one or both) ──
 
 # LangSmith

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ You need at least one AI provider configured:
 **OpenAI** (agent painting only, concept art still uses Gemini)
 - Add `OPENAI_API_KEY=your_key` to `.env`
 
+**OpenAI-compatible servers** (Llama.cpp, VLLM, LM Studio, OpenRouter, etc.)
+- Point at any OpenAI-compatible endpoint and register the model names you want in the UI:
+  ```bash
+  OPENAI_BASE_URL=http://localhost:8080/v1
+  OPENAI_MODELS=llama-3.1-8b-instruct,qwen2.5-coder-7b
+  # OPENAI_API_KEY=optional_for_local_servers   # required for hosted ones like OpenRouter
+  ```
+- Models listed in `OPENAI_MODELS` appear in the model dropdown alongside the built-in OpenAI models.
+
 All providers can be configured simultaneously — choose the model per generation in the UI.
 
 > **Want to run 100% free?** Install Ollama, pull a model, set `OLLAMA_MODELS` in `.env`, and you're done. No API keys needed. Concept art generation requires Gemini, but you can skip it and paint directly.

--- a/agent.py
+++ b/agent.py
@@ -502,6 +502,10 @@ OPENAI_MODEL_PREFIXES = ("gpt-", "o1-", "o3-")
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
 OLLAMA_MODELS = set(m.strip() for m in os.getenv("OLLAMA_MODELS", "").split(",") if m.strip())
 
+# OpenAI / OpenAI-compatible config (Llama.cpp, VLLM, LM Studio, etc.)
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL")
+OPENAI_MODELS_ENV = set(m.strip() for m in os.getenv("OPENAI_MODELS", "").split(",") if m.strip())
+
 def _get_llm(model_name: str, temperature: float = 0.7):
     # Ollama models (OpenAI-compatible API)
     if model_name in OLLAMA_MODELS:
@@ -513,10 +517,17 @@ def _get_llm(model_name: str, temperature: float = 0.7):
             api_key="ollama",
         )
 
-    # OpenAI models
-    if model_name.startswith(OPENAI_MODEL_PREFIXES):
+    # OpenAI / OpenAI-compatible models (custom names registered via OPENAI_MODELS, or standard prefixes)
+    if model_name in OPENAI_MODELS_ENV or model_name.startswith(OPENAI_MODEL_PREFIXES):
         from langchain_openai import ChatOpenAI
-        return ChatOpenAI(model=model_name, temperature=temperature)
+        kwargs: dict = {"model": model_name, "temperature": temperature}
+        if OPENAI_BASE_URL:
+            kwargs["base_url"] = OPENAI_BASE_URL
+            # Local OpenAI-compatible servers usually don't require a real key, but ChatOpenAI
+            # still expects something — fall back to a placeholder if OPENAI_API_KEY is unset.
+            if not os.getenv("OPENAI_API_KEY"):
+                kwargs["api_key"] = "not-needed"
+        return ChatOpenAI(**kwargs)
 
     # Gemini via API key
     if os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY"):

--- a/server.py
+++ b/server.py
@@ -71,9 +71,12 @@ OPENAI_MODELS = [
     "gpt-4.1-2025-04-14",
     "gpt-4o-mini",
 ]
+# Extra OpenAI / OpenAI-compatible model names (Llama.cpp, VLLM, LM Studio, etc.) registered via env.
+# Combined with OPENAI_BASE_URL in agent.py to route requests to a local/self-hosted endpoint.
+OPENAI_MODELS_CUSTOM = [m.strip() for m in os.getenv("OPENAI_MODELS", "").split(",") if m.strip()]
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
 OLLAMA_MODELS = [m.strip() for m in os.getenv("OLLAMA_MODELS", "").split(",") if m.strip()]
-ALL_MODELS = GEMINI_MODELS + OPENAI_MODELS + OLLAMA_MODELS
+ALL_MODELS = GEMINI_MODELS + OPENAI_MODELS + OPENAI_MODELS_CUSTOM + OLLAMA_MODELS
 DEFAULT_MODEL = "gemini-3-flash-preview"
 IMAGE_GEN_MODELS = [
     "gemini-3.1-flash-image-preview",


### PR DESCRIPTION
## Summary
- Adds `OPENAI_BASE_URL` env var so the agent can talk to any OpenAI-compatible endpoint (Llama.cpp, VLLM, LM Studio, OpenRouter, etc.)
- Adds `OPENAI_MODELS` env var to register custom model names — they show up in the UI dropdown and are routed through the OpenAI client
- Falls back to a placeholder API key when `OPENAI_BASE_URL` is set without `OPENAI_API_KEY`, so local servers that don't require auth work out of the box
- Documents the new "Option 4" provider in `.env.example` and `README.md`

Existing `OPENAI_API_KEY` flow is unchanged.

Closes #1

## Test plan
- [x] With `OPENAI_BASE_URL=http://localhost:8080/v1` + `OPENAI_MODELS=my-local-model`, model appears in dropdown and generation routes to the local server
- [x] With only `OPENAI_API_KEY` set (no `OPENAI_BASE_URL`), behavior matches `main`
- [x] With `OPENAI_BASE_URL` set against a hosted provider that requires auth (e.g. OpenRouter), `OPENAI_API_KEY` is forwarded as the bearer token

🤖 Generated with [Claude Code](https://claude.com/claude-code)