### PR TITLE
Point example model pull command to huggingface.co and add Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You need at least one AI provider configured:
 **Ollama (free, runs locally)**
 - Install [Ollama](https://ollama.com) and pull a model:
   ```bash
-  ollama pull ggml-org/gemma-4-E4B-it-GGUF:Q8_0
+  ollama pull hf.co/ggml-org/gemma-4-E4B-it-GGUF:Q8_0
   ```
 - Add to `.env`:
   ```bash

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Diffusion models hallucinate pixels. This tool places them.
 
 ## Setup
 
+### Unix/MacOS
 ```bash
 git clone https://github.com/EYamanS/texel-studio.git
 cd texel-studio
@@ -84,6 +85,22 @@ source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env       # edit with your API key(s)
 cd frontend && npm install && npm run build && cd ..
+python server.py
+```
+
+Open `http://localhost:8500`
+
+### Windows
+
+```bash
+python -m venv venv
+venv\Scripts\activate
+pip install -r requirements.txt
+copy .env.example .env       # edit with your API key(s)
+cd frontend
+npm install
+npm run build
+cd ..
 python server.py
 ```
 


### PR DESCRIPTION
# Summary

Wondering if defaulting to HuggingFace.co would be better for end-users so they don't have to download the models into their local ollama manually.