### PR TITLE
feat: extract color palette from reference image & improve local Ollama support

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -19,6 +19,9 @@ from langgraph.prebuilt import create_react_agent
 from langgraph.checkpoint.memory import MemorySaver
 
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 # ── Checkpointer factory ──
@@ -548,11 +551,13 @@ def _get_llm(model_name: str, temperature: float = 0.7):
     # Ollama models (OpenAI-compatible API)
     if model_name in OLLAMA_MODELS:
         from langchain_openai import ChatOpenAI
+        num_ctx = int(os.getenv("OLLAMA_NUM_CTX", "32768"))
         return ChatOpenAI(
             model=model_name,
             temperature=temperature,
             base_url=f"{OLLAMA_URL}/v1",
             api_key="ollama",
+            extra_body={"options": {"num_ctx": num_ctx}},
         )
 
     # OpenAI / OpenAI-compatible models (custom names registered via OPENAI_MODELS, or standard prefixes)

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -260,6 +260,14 @@ export function ControlPanel({ studio }: { studio: any }) {
                   <button className="btn flex-1" onClick={handleRevise}>revise</button>
                   <button className="btn btn-danger" onClick={studio.clearReference}>x</button>
                 </div>
+                <button
+                  className="btn w-full mt-1.5"
+                  style={{ fontSize: "10px" }}
+                  onClick={studio.extractReferencePalette}
+                  title="Extract colors from reference into active palette"
+                >
+                  copy palette from ref
+                </button>
               </motion.div>
             )}
           </AnimatePresence>

--- a/frontend/src/hooks/useStudio.ts
+++ b/frontend/src/hooks/useStudio.ts
@@ -117,6 +117,25 @@ export function useStudio() {
     setRefConfirmed(false);
   }, []);
 
+  const extractReferencePalette = useCallback(async () => {
+    if (!referenceId) return;
+    try {
+      const data = await api<{ colors: string[] }>(`/reference/${referenceId}/palette`);
+      if (data?.colors?.length) {
+        const palName = `Ref Palette (${data.colors.length}c)`;
+        const newPal = await api<Palette>("/palettes", {
+          method: "POST",
+          body: JSON.stringify({ name: palName, colors: data.colors }),
+        });
+        await loadPalettes();
+        setCurrentPalette(newPal);
+        setSelectedColorIdx(0);
+      }
+    } catch (e) {
+      console.error("Failed to extract palette from reference:", e);
+    }
+  }, [referenceId, loadPalettes]);
+
   // ── Generation (SSE) ──
   const generate = useCallback(async (opts: {
     prompt: string;
@@ -310,6 +329,7 @@ export function useStudio() {
     loadSettings, loadPalettes, loadHistory,
     selectPalette, setSelectedColorIdx, addColor, savePaletteAs,
     generateReference, reviseReference, uploadReference, confirmReference, clearReference,
+    extractReferencePalette,
     generate, sendChat, skipAndFinalize,
     loadGeneration, deleteGeneration,
     setPixel, setSpriteSize, setPixelData,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ langsmith>=0.7.0
 posthog>=3.0.0
 redis>=5.0.0
 boto3>=1.35.0
+langchain-openai>=0.2.0

--- a/server.py
+++ b/server.py
@@ -77,7 +77,7 @@ OPENAI_MODELS_CUSTOM = [m.strip() for m in os.getenv("OPENAI_MODELS", "").split(
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
 OLLAMA_MODELS = [m.strip() for m in os.getenv("OLLAMA_MODELS", "").split(",") if m.strip()]
 ALL_MODELS = GEMINI_MODELS + OPENAI_MODELS + OPENAI_MODELS_CUSTOM + OLLAMA_MODELS
-DEFAULT_MODEL = "gemini-3-flash-preview"
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gemini-3-flash-preview")
 IMAGE_GEN_MODELS = [
     "gemini-3.1-flash-image-preview",
 ]
@@ -885,6 +885,33 @@ def serve_reference(ref_id: str):
         raise HTTPException(404)
     return Response(content=data, media_type="image/png")
 
+@app.get("/api/reference/{ref_id}/palette")
+def extract_reference_palette(ref_id: str, max_colors: int = 16):
+    """Extract dominant palette colors from a reference image."""
+    from collections import Counter
+    import storage
+    data = storage.read_file(f"references/{ref_id}")
+    if not data:
+        raise HTTPException(404, "Reference not found")
+
+    img = Image.open(io.BytesIO(data)).convert("RGBA")
+    opaque = [p[:3] for p in img.getdata() if p[3] >= 128]
+    if not opaque:
+        return {"colors": ["#000000"]}
+
+    counts = Counter(opaque)
+    if len(counts) <= max_colors:
+        raw_colors = [c for c, _ in counts.most_common(max_colors)]
+    else:
+        flat = Image.new("RGB", (len(opaque), 1))
+        flat.putdata(opaque)
+        q = flat.quantize(colors=max_colors, method=Image.Quantize.MEDIANCUT)
+        pal = q.getpalette()[:max_colors * 3]
+        raw_colors = [(pal[i], pal[i+1], pal[i+2]) for i in range(0, len(pal), 3)]
+
+    raw_colors.sort(key=lambda c: 0.299 * c[0] + 0.587 * c[1] + 0.114 * c[2])
+    return {"colors": [f"#{r:02x}{g:02x}{b:02x}" for r, g, b in raw_colors]}
+
 # ── Generation endpoints ──
 
 @app.get("/api/generations")
@@ -938,7 +965,7 @@ async def start_generation(data: GenerateRequest):
         raise HTTPException(400, "Colors array is required")
 
     db = get_db()
-    model = data.model if data.model in GEMINI_MODELS else DEFAULT_MODEL
+    model = data.model if data.model in ALL_MODELS else DEFAULT_MODEL
     cur = db.execute(
         "INSERT INTO generations (prompt, system_prompt, colors, size, model, reference_id, sprite_type) VALUES (?, ?, ?, ?, ?, ?, ?)",
         (data.prompt, data.system_prompt, json.dumps(data.colors), data.size, model, data.reference_id, data.sprite_type),


### PR DESCRIPTION
### Summary

1. **Palette extraction from reference images**:
 - Adds `GET /api/reference/{ref_id}/palette` which extracts up to 16 dominant colors from any reference image.
 - Preserves exact colors for indexed pixel-art sprites (≤ 16 colors) and ignores alpha transparency so empty backgrounds don't pollute the palette.
 - For photos or concept art (> 16 colors), quantizes colors using PIL's Median Cut down to the top representative palette colors.
 - Sorts the palette by luminance (dark to light) so swatches look clean and structured.
 - Adds a **"copy palette from ref"** button directly in `ControlPanel.tsx` underneath the reference preview to load and select the palette with 1 click.

2. **Ollama & Local LLM Fixes**:
 - Adds `langchain-openai` to `requirements.txt` (previously imported in `agent.py` but missing from dependencies).
 - Configures `num_ctx` (default 32,768, configurable via `OLLAMA_NUM_CTX` env var) in `ChatOpenAI` options to prevent exceed_context_size_error (8194 tokens > 8192 tokens)` when vision references or long tool histories are  used.
 - Fixes model selection check in `server.py` line 941 to validate against `ALL_MODELS` instead of only `GEMINI_MODELS`.
 - Adds `load_dotenv()` in `agent.py` so background tasks and standalone workers inherit `.env` configurations.

 ### Testing
    - Tested palette extraction on RGBA and palette-indexed pixel art images.
    - Tested local generation with Ollama (`qwen3-vl:8b-instruct`) using uploaded reference images with 32k context window.